### PR TITLE
Separate -writeaddress so it prints

### DIFF
--- a/build/docker/tests/setup.sh
+++ b/build/docker/tests/setup.sh
@@ -99,12 +99,23 @@ do
 
     # Generate an Ether account for the node
     touch $qd/passwords.txt
-    account=`docker run -v $pwd/$qd:/qdata $image_quorum /usr/local/bin/geth --datadir=/qdata/dd --password /qdata/passwords.txt account new | cut -c 11-50`
+    create_account="docker run -v $pwd/$qd:/qdata $image_quorum /usr/local/bin/geth --datadir=/qdata/dd --password /qdata/passwords.txt account new"
+    account1=`$create_account | cut -c 11-50`
+    account2=`$create_account | cut -c 11-50`
+    account3=`$create_account | cut -c 11-50`
+    account4=`$create_account | cut -c 11-50`
+    echo "Accounts for node $n: $account1 $account2 $account3 $account4"
 
     # Add the account to the genesis block so it has some Ether at start-up
     sep=`[[ $n < $nnodes ]] && echo ","`
     cat >> genesis.json <<EOF
-    "${account}": {
+    "${account1}": {
+      "balance": "1000000000000000000000000000"
+    }, "${account2}": {
+      "balance": "1000000000000000000000000000"
+    }, "${account3}": {
+      "balance": "1000000000000000000000000000"
+    }, "${account4}": {
       "balance": "1000000000000000000000000000"
     }${sep}
 EOF

--- a/build/docker/tests/setup.sh
+++ b/build/docker/tests/setup.sh
@@ -37,7 +37,7 @@ then
     echo "ERROR: There must be more than one node IP address."
     exit 1
 fi
-   
+
 ./scripts/cleanup.sh
 
 cd tmp
@@ -69,7 +69,10 @@ do
     qd=qdata_$n
 
     # Generate the node's Enode and key
-    enode=`docker run -v $pwd/$qd:/qdata $image_quorum /usr/local/bin/bootnode -genkey /qdata/dd/nodekey -writeaddress`
+    bootnode_cmd="docker run -it -v $pwd/$qd:/qdata $image_quorum /usr/local/bin/bootnode"
+    $bootnode_cmd -genkey /qdata/dd/nodekey
+    enode=`$bootnode_cmd -nodekey /qdata/dd/nodekey -writeaddress | tr -d '[:space:]'`
+    echo "Node $n id: $enode"
 
     # Add the enode to static-nodes.json
     sep=`[[ $n < $nnodes ]] && echo ","`


### PR DESCRIPTION
Found this trying the docker compose set up. Not the full answer, but gets full hex strings into the URIs in `static-nodes.json`