### PR TITLE
constellation nodes unable to discover and communicate with each other

### DIFF
--- a/build/docker/constellation/start.sh
+++ b/build/docker/constellation/start.sh
@@ -11,4 +11,4 @@ set -e
 TMCONF=/qdata/tm.conf
 
 echo "[*] Starting Constellation node"
-nohup /usr/local/bin/constellation-node $TMCONF -v3
+nohup /usr/local/bin/constellation-node $TMCONF -v3 2>>/qdata/logs/constellation.log

--- a/build/docker/geth/start.sh
+++ b/build/docker/geth/start.sh
@@ -18,4 +18,4 @@ if [ ! -d /qdata/dd/geth/chaindata ]; then
 fi
 
 echo "[*] Starting node"
-PRIVATE_CONFIG=$TMCONF nohup /usr/local/bin/geth $GETH_ARGS
+PRIVATE_CONFIG=$TMCONF nohup /usr/local/bin/geth $GETH_ARGS 2>>/qdata/logs/geth.log

--- a/build/docker/tests/setup.sh
+++ b/build/docker/tests/setup.sh
@@ -24,6 +24,15 @@
 subnet="172.13.0.0/16"
 ips=("172.13.0.3" "172.13.0.5")
 
+cips=()
+## constellation node uses IP address derived from
+## the corresponding geth node IP address by subtracting 1
+for ip in ${ips[*]}
+do
+    [[ $ip =~ (.*\.)([0-9]+)$ ]] && cip=${BASH_REMATCH[2]}
+    cips+=("${BASH_REMATCH[1]}$(($cip - 1))")
+done
+
 # Docker image name
 image_constellation=jpmorganchase/constellation
 image_quorum=jpmorganchase/quorum
@@ -144,9 +153,9 @@ EOF
 
 nodelist=
 n=1
-for ip in ${ips[*]}
+for ip in ${cips[*]}
 do
-    sep=`[[ $ip != ${ips[0]} ]] && echo ","`
+    sep=`[[ $ip != ${cips[0]} ]] && echo ","`
     nodelist=${nodelist}${sep}'"http://'${ip}':9000/"'
     let n++
 done
@@ -157,12 +166,12 @@ done
 echo '[4] Creating Quorum keys and finishing configuration.'
 
 n=1
-for ip in ${ips[*]}
+for ip in ${cips[*]}
 do
     qd=qdata_$n
 
     cat ../templates/tm.conf \
-        | sed s/_NODEIP_/${ips[$((n-1))]}/g \
+        | sed s/_NODEIP_/${cips[$((n-1))]}/g \
         | sed s%_NODELIST_%$nodelist%g \
               > $qd/tm.conf
 
@@ -185,14 +194,11 @@ version: '2'
 services:
 EOF
 
-n=1
-for ip in ${ips[*]}
-do
+for index in ${!ips[*]}; do 
+    n=$((index+1))
     qd=qdata_$n
-    ## constellation node uses IP address derived from
-    ## the corresponding geth node IP address by subtracting 1
-    [[ $ip =~ (.*\.)([0-9]+)$ ]] && cip=${BASH_REMATCH[2]}
-    cip="${BASH_REMATCH[1]}$(($cip + 1))"
+    ip=${ips[index]}; 
+    cip=${cips[index]}; 
 
     cat >> docker-compose.yml <<EOF
   constellation_$n:
@@ -219,8 +225,6 @@ do
     ipc: container:constellation_$n
 
 EOF
-
-    let n++
 done
 
 cat >> docker-compose.yml <<EOF


### PR DESCRIPTION
Issue: 
- docker-compose.yml had ip addresses that were generated by adding one to the ip addresses that were provided for quorum nodes/geth 
- tm.conf was being generated to use the ip addresses provided for the quorum nodes as it is
- docker startup.sh for both geth and constellation wasn't redirecting output to the logs (making it harder to read the logs unless we explicitly attached to the docker container) 

Fix: 
- generate the constellation ips up front (using -1 scheme as the comment originally suggested) 
- updated code to utilize the constellation ip addresses when generating tm.conf (for both advertised url as well as othernodes)
- redirected to logs to /qdata/logs for both constellation and geth